### PR TITLE
feat: blacklist .dog telegram domain

### DIFF
--- a/src/main/java/ke/co/proxyapi/spamblocker/services/MessageProcessor.java
+++ b/src/main/java/ke/co/proxyapi/spamblocker/services/MessageProcessor.java
@@ -85,7 +85,7 @@ public class MessageProcessor implements Processor
 
 	private boolean hasTgLink(String message)
 	{
-		Set<String> tgDomains = Set.of("t.me", "telegram.me");
+		Set<String> tgDomains = Set.of("t.me", "telegram.me","telegram.dog");
 
 		UrlDetector parser = new UrlDetector(message, UrlDetectorOptions.HTML);
 		List<Url> urlList = parser.detect();


### PR DESCRIPTION
#### What does this PR do?
Adds `telegram.dog` domain to the blacklist.

#### Additional information about this issue
All these links works fine and are fully supported
https://telegram.dog/murageyun
https://telegram.me/murageyun
https://t.me/murageyun
